### PR TITLE
Add support for whispering images

### DIFF
--- a/scripts/image-manager/chat-handling.js
+++ b/scripts/image-manager/chat-handling.js
@@ -1,8 +1,9 @@
 'use strict';
 
-import {compressAndSendEmbedded, compressAndSendFile, isGif} from "./file-manager.js";
-import {getUploadPermissionStatus, localize, isAfterFoundry8, MODULE_NAME} from "../utils.js";
-import {getSetting} from "../settings.js";
+import { compressAndSendEmbedded, compressAndSendFile, isGif } from "./file-manager.js";
+import { getUploadPermissionStatus, localize, isAfterFoundry8, MODULE_NAME, chatContainsWhisper, appendChat } from "../utils.js";
+import { getSetting } from "../settings.js";
+import { htmlPrefilter } from "jquery";
 
 /**
  * Creates an HTML template with an image wrapped in the module's container
@@ -24,6 +25,8 @@ function messageTemplate(URL) {
  * @return {Promise<*>}
  */
 function createChatMessage(content, cb) {
+    const template = messageTemplate(content);
+    const content = chatContainsWhisper() ? template : appendChat(template);
     const messageData = {
         content: messageTemplate(content),
         // fix for #20: added a `type OOC`, so the message will

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -75,6 +75,19 @@ function getUploadPermissionStatus() {
     return game?.permissions?.FILES_UPLOAD?.includes(game?.user?.role);
 }
 
+function chatContainsWhisper() {
+    const whisperRe = new RegExp('^\/w\s\S+')
+    let $chat = html.find('#chat-form textarea');
+    let chat_val = String($chat.val());
+    return whisperRe.test(chat_val);
+}
+
+function appendChat(message) {
+    let $chat = html.find('#chat-form textarea');
+    let chat_val = String($chat.val());
+    return chat_val + ' ' + message;
+}
+
 /**
  * Returns the foundry version
  *


### PR DESCRIPTION
Hi! First off amazing module, it's fantastic! Second I'm super inexperienced with JavaScript so please help me where I've made horrible mistakes 😅. This is an attempt to add the ability to whisper images if the chat field is populated with a regex valid whisper string. Currently this works as intended if the message is a whisper with a URL i.e.:

```
/w Person IMAGE_URL
```

But this doesn't seem to be possible when uploading an image. This PR is an attempt to add that feature.

Ideally the user could populate their chatbox with `/w Person` and then drag an image to the chat and have it sent as a whisper to `Person`